### PR TITLE
release: v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "introspector-gadget"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "GraphQL introspection utilities"


### PR DESCRIPTION
## 0.2.0

### ❗ BREAKING ❗

- **Infallible `GraphQLCLient` constructor**

`GraphQLClient::new` now returns a `GraphQLClient` instead of a `Result<GraphQLClient, reqwest::Error>`, which should make for a lighter burden on library consumers (especially since it is impossible for that function to ever return an error).