### PR TITLE
Update apollo-encoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Apollo Developers <opensource@apollographql.com>"]
 readme = "README.md"
 
 [dependencies]
-apollo-encoder = "0.3.2"
+apollo-encoder = "0.4.0"
 backoff = "0.4"
 graphql_client = "0.11.0"
 hyper = "0.14"


### PR DESCRIPTION
the only breaking change is the apollo-parser update, which is not used by this crate.