### PR TITLE
chore: bumps graphql-client from 0.11.0 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 apollo-encoder = "0.4.0"
 backoff = "0.4"
-graphql_client = "0.11.0"
+graphql_client = "0.13"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",


### PR DESCRIPTION
this commit also increases the range of allowed versions of graphql-client to any patch of 0.13 instead of requiring an exact match of 0.13.0.

this way packages that depend on introspector-gadget and also use graphql-client themselves are able to use the most up to date version rather than requiring a bump upstream (here) first.