### PR TITLE
chore: update rust 1.63.0 => 1.70.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   cargo-test:
     docker:
-      - image: cimg/rust:1.63.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
It seems that build no longer passes on the master branch.

The build was failing with:

```
   Compiling apollo-parser v0.5.3
error[E0658]: `let...else` statements are unstable
   --> /home/circleci/.cargo/registry/src/github.com-1ecc6299db9ec823/apollo-parser-0.5.3/src/lexer/mod.rs:166:9
    |
166 | /         let Some(c) = self.bump() else {
167 | |             return Err(Error::new(
168 | |                 "unexpected end of data while lexing string value",
169 | |                 "\"".to_string(),
170 | |             ));
171 | |         };
    | |__________^
    |
    = note: see issue #87335 <https://github.com/rust-lang/rust/issues/87335> for more information

error[E0658]: `let...else` statements are unstable
   --> /home/circleci/.cargo/registry/src/github.com-1ecc6299db9ec823/apollo-parser-0.5.3/src/ast/node_ext.rs:163:17
    |
163 | /                 let Some(c2) = iter.next() else {
164 | |                     output.push(c);
165 | |                     break;
166 | |                 };
    | |__________________^
    |
    = note: see issue #87335 <https://github.com/rust-lang/rust/issues/87335> for more information
```